### PR TITLE
Fallback for ro.arch and Firmware under newer versions

### DIFF
--- a/SnoopSnitch/app/src/main/java/de/srlabs/snoopsnitch/util/MsdLog.java
+++ b/SnoopSnitch/app/src/main/java/de/srlabs/snoopsnitch/util/MsdLog.java
@@ -157,7 +157,7 @@ public class MsdLog {
                     + "gsm.version.ril-impl:  " + osgetprop("gsm.version.ril-impl") + "\n"
                     + "ril.hw_ver:            " + osgetprop("ril.hw_ver") + "\n"
                     + "ril.modem.board:       " + osgetprop("ril.modem.board") + "\n"
-                    + "ro.arch:               " + osgetprop("ro.arch") + "\n"
+                    + "ro.arch:               " + (osgetprop("ro.arch").equals("<n/a>") ? System.getProperty("os.arch") : osgetprop("ro.arch")) + "\n"
                     + "ro.board.platform:     " + osgetprop("ro.board.platform") + "\n";
         } catch (Exception ee) {
             Log.e(TAG, mTAG + "Exception in getDeviceProps(): Unable to retrieve system properties: " + ee);
@@ -186,7 +186,7 @@ public class MsdLog {
         result.append("gsm.version.ril-impl:  " + osgetprop("gsm.version.ril-impl") + "\n");
         result.append("ril.hw_ver:            " + osgetprop("ril.hw_ver") + "\n");
         result.append("ril.modem.board:       " + osgetprop("ril.modem.board") + "\n");
-        result.append("ro.arch:               " + osgetprop("ro.arch") + "\n");
+        result.append("ro.arch:               " + (osgetprop("ro.arch").equals("<n/a>") ? System.getProperty("os.arch") : osgetprop("ro.arch")));
         result.append("ro.board.platform:     " + osgetprop("ro.board.platform") + "\n");
         result.append("/dev/diag info:\n	  " + Utils.checkDiag() + "\n");
         return result.toString();

--- a/SnoopSnitch/app/src/main/java/de/srlabs/snoopsnitch/util/Utils.java
+++ b/SnoopSnitch/app/src/main/java/de/srlabs/snoopsnitch/util/Utils.java
@@ -531,10 +531,24 @@ public class Utils {
             result = bis.readLine();
         } catch (Exception ee) {
             Log.e(TAG, mTAG + ":getProcVersionInfo() Exception: " + ee);
-            return null;
+
+            result = "";
+
+            try {
+                Process proc = Runtime.getRuntime()
+                        .exec(new String[] { "su", "-c", "cat", infoFile, "exit" });
+                proc.waitFor();
+                java.util.Scanner s = new java.util.Scanner(proc.getInputStream()).useDelimiter("\\A");
+                String output = s.hasNext() ? s.next() : "";
+                result = output;
+            } catch(Exception e) {
+                result = "<n/a>";
+            }
+
+
         }
         Log.i(TAG, "/proc/version: " + "\"" + result + "\"");
-        return result;
+        return result.isEmpty() ? "<n/a>" : result;
     }
 
     /**


### PR DESCRIPTION
Newer Android versions restrict access to the `/proc` filesystem for privacy reasons. This commit fixes #2 by adding a fallback for root users and finally a consistent return of  `<n/a>` in case it fails. Additionally there is now a fallback for obtaining the processor arch.